### PR TITLE
make cache dir relative to script

### DIFF
--- a/app.R
+++ b/app.R
@@ -9,7 +9,9 @@ library(scales)
 
 source('render-site-map.R')
 
-cache_path <- "/srv/shiny-server/cache/cache.RData"
+# create cache folder in same directory as this script (will do nothing if already exists)
+dir.create("./cache", showWarnings = FALSE)
+cache_path <- "./cache/cache.RData"
 cache_mod_time <- file.mtime(cache_path)
 full_cache_data <- NA
 

--- a/cache-refresh.R
+++ b/cache-refresh.R
@@ -13,9 +13,9 @@ bety_src <- src_postgres(
 )
 
 # create cache folder in same directory as this script (will do nothing if already exists)
-dir.create("cache", showWarnings = FALSE)
-cache_path <- "cache/cache.RData"
-cache_path_temp <- "cache/cache.RData.tmp"
+dir.create("./cache", showWarnings = FALSE)
+cache_path <- "./cache/cache.RData"
+cache_path_temp <- "./cache/cache.RData.tmp"
 
 # get all relevant data from BETYdb for a given subexperiment, write to cache file
 get_data_for_subexp <- function(subexp, exp_name) {

--- a/cache-refresh.R
+++ b/cache-refresh.R
@@ -12,8 +12,10 @@ bety_src <- src_postgres(
  user     = ifelse(Sys.getenv('bety_user')     == '', 'bety', Sys.getenv('bety_user'))
 )
 
-cache_path <- "/srv/shiny-server/cache/cache.RData"
-cache_path_temp <- "/srv/shiny-server/cache/cache.RData.tmp"
+# create cache folder in same directory as this script (will do nothing if already exists)
+dir.create("cache", showWarnings = FALSE)
+cache_path <- "cache/cache.RData"
+cache_path_temp <- "cache/cache.RData.tmp"
 
 # get all relevant data from BETYdb for a given subexperiment, write to cache file
 get_data_for_subexp <- function(subexp, exp_name) {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,8 @@ server)
 
 update)
   echo "Starting cache-refresh script."
-  exec Rscript ./srv/shiny-server/cache-refresh.R
+  cd /srv/shiny-server
+  exec Rscript ./cache-refresh.R
   ;;
 
 *)


### PR DESCRIPTION
Store cache files in a /cache directory relative to the script.

Currently we require the cache folder to be separate from the folder containing the app files because we mount it into the Docker VM from the condo storage system so that the cache is preserved across VMs - removing the folder would result in problems.