### PR TITLE
Add url parameter support 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN install2.r --error \
          RPostgreSQL \
          timevis \
          kableExtra \
+         shiny.router
       && rm -rf /srv/shiny-server/sample-apps
 
 RUN apt-get install -y \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN install2.r --error \
          RPostgreSQL \
          timevis \
          kableExtra \
-         shiny.router
+         shiny.router \
       && rm -rf /srv/shiny-server/sample-apps
 
 RUN apt-get install -y \

--- a/README.md
+++ b/README.md
@@ -141,9 +141,11 @@ Shiny server: see https://www.rstudio.com/products/shiny/download-server/
 - mapview
 - leafem
 - sf
+- shiny.router
 
 ```r
-install.packages(c('shiny', 'shinythemes', 'lubridate', 'dplyr', 'ggplot2', 'timevis', 'rgeos', 'leaflet', 'cronR', 'stringr', 'kableExtra', 'raster', 'mapview', 'leafem', 'sf'))
+install.packages(c('shiny', 'shinythemes', 'lubridate', 'dplyr', 'ggplot2', 'timevis', 'rgeos', 'leaflet', 'cronR', 'stringr', 'kableExtra', 'raster', 'mapview', 'leafem', 'sf',
+'shiny.router'))
 ```
 
 #### Deploy

--- a/app.R
+++ b/app.R
@@ -581,6 +581,7 @@ server <- shinyServer(function(input, output, session) {
   router(input, output, session)
 })
 
+shinyApp(ui = ui, server = server)
 server <- function(input, output) {
   
   # load 'full_cache_data' object from cache file

--- a/app.R
+++ b/app.R
@@ -122,6 +122,54 @@ render_cultivar_menu <- function(subexp_name, id_str, input, output, full_cache_
   })
 }
 
+# generate trait plot
+render_trait_plot <- function(plot_data, selected_variable, selected_cultivar, units, start_date, end_date){
+  data_max <- max(plot_data[[ 'mean' ]])
+  unique_vals <- unique(plot_data[[ 'mean' ]])
+  all_vals_integers <- all(unique_vals %% 1 == 0)
+  num_unique_vals <- length(unique_vals)
+  
+  plot_data$method[is.na(plot_data$method) | plot_data$method == 'NA'] <- 'Not Provided'
+  
+  trait_plot <- ggplot(data = plot_data, aes(x = as.Date(date), y = mean, color = method)) +
+    scale_colour_brewer(palette = "Set1")
+  
+  {
+    if ((num_unique_vals < 20) & (max(unique_vals) < 30) & all_vals_integers) {
+      trait_plot <- trait_plot + 
+        geom_count() + 
+        geom_vline(aes(xintercept = as.numeric(as.Date(date))),
+                   color = 'grey')
+    } else {
+      trait_plot <- trait_plot + 
+        geom_violin(scale = 'width', width = 1, aes(group = as.Date(date))) +
+        geom_boxplot(outlier.alpha = 0.25, width = 0.2, aes(group = as.Date(date)))
+    }
+    }
+  
+  if (selected_cultivar != 'None') {
+    title <- paste0(selected_variable, '\nCultivar ', selected_cultivar, ' in red')
+    trait_plot <- trait_plot + 
+      geom_point(data = subset(plot_data, cultivar_name == selected_cultivar), 
+                 aes(x = as.Date(date), y = mean, group = site_id)) +
+      geom_line(data = subset(plot_data, cultivar_name == selected_cultivar), 
+                size = 0.5, alpha = 0.5, aes(x = as.Date(date), y = mean, group = site_id)) 
+  } else {
+    title <- selected_variable
+  }
+  
+  trait_plot + 
+    labs(
+      title = paste0(title, '\n'),
+      x = "Date",
+      y = units
+    ) +
+    theme_bw() + 
+    theme(text = element_text(size = 20), axis.text.x = element_text(angle = 45, hjust = 1)) +
+    xlim(start_date, end_date) +
+    ylim(0, data_max)
+}
+
 # render box plot time series from trait records in a given subexperiment, for the selected variable
 # if a cultivar is selected, render line plot from trait records for that cultivar
 render_plot <- function(subexp_name, id_str, input, output, full_cache_data) {

--- a/app.R
+++ b/app.R
@@ -13,6 +13,8 @@ library(shiny.router)
 source('render-site-map.R')
 source('render-trait-plot.R')
 source('render-mgmt-timeline.R')
+source('render-home-outputs.R')
+source('render-search-outputs.R')
 
 # create cache folder in same directory as this script (will do nothing if already exists)
 dir.create("./cache", showWarnings = FALSE)
@@ -37,15 +39,7 @@ load_cache <- function(full_cache_data) {
     }
 }
 
-# directory containing full-field images
-image_dir <- '~/data/terraref/sites/ua-mac/Level_2/rgb_fullfield/_thumbs'
-
-if(dir.exists(image_dir)){
-# dates that have full-field images
-  image_dates <- as.Date(unique(unlist(str_extract_all(list.files(image_dir),'[0-9]{4}-[0-9]{2}-[0-9]{2}'))))
-} 
-
-# render UI for a given subexperiment
+# render UI for a given subexperiment for home page
 render_subexp_ui <- function(subexp_name, exp_name) {
   
   id_str <- paste0(exp_name, '_', subexp_name)
@@ -100,220 +94,7 @@ render_experiment_ui <- function(exp_name, full_cache_data) {
   )
 }
 
-# render selection menu from available variables in a given subexperiment
-render_variable_menu <- function(subexp_name, id_str, output, full_cache_data) {
-  
-  variable_names <- names(full_cache_data[[ subexp_name ]][[ 'trait_data' ]])
-  
-  output[[ paste0('variable_select_', id_str) ]] <- renderUI({
-    selectInput(paste0('selected_variable_', id_str), 'Variable', variable_names)
-  })
-}
-
-# render selection menu from available cultivars in a given subexperiment, for the selected variable
-render_cultivar_menu <- function(subexp_name, id_str, input, output, full_cache_data) {
-  
-  output[[ paste0('cultivar_select_', id_str) ]] <- renderUI({
-    
-    req(input[[ paste0('selected_variable_', id_str) ]])
-    
-    trait_records <- full_cache_data[[ subexp_name ]][[ 'trait_data' ]][[ input[[ paste0('selected_variable_', id_str) ]] ]][[ 'traits' ]]
-    unique_cultivars <- unique(trait_records[[ 'cultivar_name' ]])
-    
-    selectInput(paste0('selected_cultivar_', id_str), 'Cultivar', c('None', unique_cultivars))
-  })
-}
-
-render_home_plot <- function(subexp_name, id_str, input, output, full_cache_data) {
-  
-  output[[ paste0('trait_plot_', id_str) ]] <- renderPlot({
-    
-    req(input[[ paste0('selected_variable_', id_str) ]])
-    req(input[[ paste0('selected_cultivar_', id_str) ]])
-    
-    selected_subexp_data <- full_cache_data[[ subexp_name ]]
-    selected_variable <- input[[ paste0('selected_variable_', id_str) ]]
-    selected_cultivar <- input[[ paste0('selected_cultivar_', id_str) ]]
-    
-    plot_data <- selected_subexp_data[[ 'trait_data' ]][[ selected_variable ]][[ 'traits' ]]
-    units <- selected_subexp_data[[ 'trait_data' ]][[ selected_variable ]][[ 'units' ]]
-    start_date <- as.Date(selected_subexp_data[[ 'start_date' ]])
-    end_date <- as.Date(selected_subexp_data[[ 'end_date' ]])
-    
-    render_trait_plot(plot_data, selected_variable, selected_cultivar, units, start_date, end_date)
-    
-  })
-}
-
-render_home_mgmt_timeline <- function(subexp_name, id_str, input, output, full_cache_data) {
-  
-  output[[ paste0('mgmt_timeline_', id_str) ]] <- renderTimevis({
-    
-    management_data <- full_cache_data[[ subexp_name ]][[ 'managements' ]]
-    
-    render_mgmt_timeline(management_data)
-    
-  })
-}
-
-render_home_plot_hover <- function(subexp_name, id_str, input, output, full_cache_data) {
-  
-  output[[ paste0('plot_hover_info_', id_str) ]] <- renderUI({
-    
-    render_plot_hover(paste0('plot_hover_', id_str), input)
-
-  })
-}
-
-
-render_home_timeline_hover <- function(subexp_name, id_str, input, output, full_cache_data) {
-  
-  output[[ paste0('mgmt_select_info_', id_str) ]] <- renderUI({
-    
-    subexp_data <- full_cache_data[[ subexp_name ]]
-    
-    render_timeline_hover(paste0('mgmt_timeline_', id_str, '_selected'), subexp_data, input)
-    
-  })
-}
-
-render_home_map <- function(subexp_name, id_str, input, output, full_cache_data) {
-  
-  # render slider input from dates in a given subexperiment
-  output[[ paste0('map_date_slider_', id_str) ]] <- renderUI({
-    
-    sliderInput(paste0('map_date_', id_str), 'Date',
-                as.Date(full_cache_data[[ subexp_name ]][[ 'start_date']]),
-                as.Date(full_cache_data[[ subexp_name ]][[ 'end_date' ]]),
-                as.Date(full_cache_data[[ subexp_name ]][[ 'end_date' ]]))
-    
-  })
-  
-  output[[ paste0('scan_options_table_', id_str) ]] <- renderText({
-  
-    req(input[[ paste0('map_date_', id_str) ]]) 
-    render_date <- input[[ paste0('map_date_', id_str) ]]
-    
-    # display scan options table for selected date if thumbs exist for date
-    if(dir.exists(image_dir) & (render_date %in% image_dates)){
-      
-      image_paths <- list.files(image_dir, pattern = as.character(render_date))
-      scan_matches <- unlist(str_match_all(image_paths,
-                                           'rgb_fullfield_L2_ua-mac_[0-9]{4}-[0-9]{2}-[0-9]{2}_(.*)_rgb_thumb\\.tif'))
-      scan_names <- str_replace_all(scan_matches[-grep('\\.tif', scan_matches)],
-                                    '_',
-                                    ' ')
-      scan_names_df <- data.frame(scan_number = 1:length(scan_names),
-                                  scan_name = scan_names)
-      scan_names_kable <- kable(scan_names_df) %>% kable_styling()
-      
-    }else{
-      return()
-    }
-    
-  })
-  
-  # render heat map of sites from trait records in a given subexperiment, for the selected date, variable and cultivar
-  output[[ paste0('site_map_', id_str) ]] <- renderLeaflet({
-    
-    req(input[[ paste0('selected_variable_', id_str) ]])
-    req(input[[ paste0('selected_cultivar_', id_str) ]])
-    req(input[[ paste0('map_date_', id_str) ]])
-    
-    selected_variable <- input[[ paste0('selected_variable_', id_str) ]]
-    selected_cultivar <- input[[ paste0('selected_cultivar_', id_str) ]]
-    render_date <- input [[ paste0('map_date_', id_str) ]]
-    
-    traits <- full_cache_data[[ subexp_name ]][[ 'trait_data' ]][[ selected_variable ]][[ 'traits' ]]
-    
-    if (selected_cultivar != 'None'){
-      traits <- subset(traits, cultivar_name == selected_cultivar)
-    }
-    
-    if(dir.exists(image_dir) & (render_date %in% image_dates)){
-      # render site map with fullfield image if thumbs available for selected date
-      overlay_image <- 1
-      render_site_map(selected_variable, traits, render_date, selected_variable, overlay_image)
-    }else{
-      render_site_map(selected_variable, traits, render_date, selected_variable)
-    }
-    
-  })
-}
-
-render_download_info <- function(exp_name, subexp_name, id_str, input, output, full_cache_data){
-  
-  output[[ paste0('download_info_', id_str) ]] <- renderUI({
-    
-    req(input[[ paste0('selected_variable_', id_str) ]])
-    selected_variable <- input[[ paste0('selected_variable_', id_str) ]]
-    
-    trait_name <- full_cache_data[[ subexp_name ]][[ 'trait_data' ]][[ selected_variable ]][[ 'name' ]]
-    
-    if(exp_name == 'Danforth Sorghum Pilot'){
-      site <- 'Danforth Plant Science Center Bellweather Phenotyping Facility'
-    }else{
-      site <- paste0('~', gsub('MAC ', '', exp_name))
-    }
-    
-    text_1 <- "<h1 style='font-size:30px;'>How to access data</h1>"
-    text_2 <- paste0("You can access <strong><em>",
-                     selected_variable,
-                     "</strong></em> data for <strong><em>",
-                     exp_name,
-                     "</strong></em>, using either:<br>")
-    text_3 <- "1.) BETYdb API<br>2.) R traits package"
-    text_4 <- "<br><h2 style='font-size:25px;'>API key</h2>"
-    text_5 <- paste0("Both methods will require an <strong>API key</strong>.<br><br>",
-                     "You can get an API key by signing up for the TERRA Ref BETYdb traits database. ",
-                     "Register for BETYdb at ",
-                     "<a href='https://terraref.ncsa.illinois.edu/bety/signup'>",
-                     "https://terraref.ncsa.illinois.edu/bety/signup</a>.<hr>")
-    text_6 <- "<h2 style='font-size:25px;'>R traits package</h2><br>"
-    text_7 <- "Install the traits package from CRAN using: <code>install.packages('traits')</code>.<br><br>"
-    text_8 <- paste0("You can then use the following chunk of R code to access the data: <br><br>",
-                     "<code>library(traits)</code><br><br>",
-                     "<code>options(betydb_url = ",
-                     "'https://terraref.ncsa.illinois.edu/bety/'",
-                     ", betydb_api_version = 'beta', ",
-                     "betydb_key = 'YOUR_API_KEY')</code><br><br>")
-    text_9 <- paste0("<code>",
-                     trait_name)
-    text_10 <- paste0(" <- betydb_query(trait = '", trait_name, "', ")
-    text_11 <- paste0("sitename = '", site, "', ")
-    text_12 <- paste0("limit = 'none')</code>")
-    text_13 <- paste0("<hr>",
-                      "<h2 style='font-size:25px;'>BETYdb API</h2><br>",
-                      "You can also access the data at this URL:<br>")
-    text_14 <- paste0("<a>https://terraref.ncsa.illinois.edu/bety/api/v1/search?",
-                      "trait=",
-                      trait_name,
-                      "&sitename=",
-                      site,
-                      "&limit=none&key=YOUR_API_KEY</a>.<br><br>",
-                      "See API <a href='https://www.betydb.org/api/docs'>documentation</a> for details.")
-    text_15 <- paste0("<hr>",
-                      "<h1 style='font-size:30px;'>TERRA REF Tutorials</h1><br>",
-                      "For more detailed information on how to access data, take a look at our tutorials.<br><br>",
-                      "GitHub repository: <a href='https://github.com/terraref/tutorials'>",
-                      "https://github.com/terraref/tutorials</a><br>",
-                      "How to access data using R traits package: ",
-                      "<a href='https://github.com/terraref/tutorials/tree/master/traits/03-access-r-traits.Rmd'>",
-                      "traits/03-access-r-traits.Rmd</a><br>",
-                      "How to access data using BETYdb API: ",
-                      "<a href='https://github.com/terraref/tutorials/tree/master/traits/02-betydb-api-access.Rmd'>",
-                      "traits/02-betydb-api-access.Rmd</a><br>")
-    
-    download_text <- HTML(paste(text_1, text_2, text_3,
-                                text_4, text_5, text_6,
-                                text_7, text_8, text_9,
-                                text_10, text_11, text_12,
-                                text_13, text_14, text_15))
-  })
-  
-}
-
-# render outputs for a given subexperiment
+# render outputs for a given subexperiment for home page
 render_subexp_output <- function(subexp_name, exp_name, input, output, full_cache_data) {
   
   id_str <- paste0(exp_name, '_', subexp_name)
@@ -348,6 +129,7 @@ render_experiment_output <- function(experiment_name, input, output, full_cache_
   lapply(names(full_cache_data[[ experiment_name ]]), render_subexp_output, experiment_name, input, output, full_cache_data[[ experiment_name ]])
 }
 
+# render ui for search page
 render_search_ui <- function(){
   fluidRow(
     column(4, leafletOutput('search_map', width = '350px', height = '700px')),
@@ -359,6 +141,7 @@ render_search_ui <- function(){
   )
 }
 
+# render outputs for search page
 render_search_output <- function(full_cache_data, input, output, exp_name, subexp_name, var, cultivar, date){
   
   render_search_map(full_cache_data, input, output,
@@ -379,66 +162,6 @@ render_search_output <- function(full_cache_data, input, output, exp_name, subex
                                exp_name, subexp_name, 'search_timeline_selected')
   
 }
-
-render_search_map <- function(full_cache_data, input, output, exp_name,
-                              subexp_name, var,
-                              cultivar = 'None', date){
-  
-  output$search_map <- renderLeaflet({
-    
-    traits <- full_cache_data[[ exp_name ]][[ subexp_name ]][[ 'trait_data' ]][[ var ]][[ 'traits' ]]
-    if (cultivar != 'None'){
-      traits <- subset(traits, cultivar_name == cultivar)
-    }
-    if(dir.exists(image_dir) & (date %in% image_dates)){
-      # render site map with fullfield image if thumbs available for selected date
-      overlay_image <- 1
-      render_site_map(var, traits, date, var, overlay_image)
-    }else{
-      # render site map without fullfield image
-      render_site_map(var, traits, date, var)
-    }
-  
-  })
-}
-
-render_search_plot <- function(full_cache_data, input, output, exp_name,
-                               subexp_name, var, cultivar){
-  
-  output$search_plot <- renderPlot({
-    subexp_data <- full_cache_data[[ exp_name ]][[ subexp_name ]]
-    traits <- subexp_data[[ 'trait_data' ]][[ var ]][[ 'traits' ]]
-    units <- subexp_data[[ 'trait_data' ]][[ var ]][[ 'units' ]]
-    start_date <- as.Date(subexp_data[[ 'start_date' ]])
-    end_date <- as.Date(subexp_data[[ 'end_date' ]])
-    render_trait_plot(traits, var, cultivar, units, start_date, end_date)
-  })
-
-}
-
-render_search_mgmt_timeline <- function(full_cache_data, output, exp_name, subexp_name){
-  
-  output$search_timeline <- renderTimevis({
-    
-    management_data <- full_cache_data[[ exp_name ]][[ subexp_name ]][[ 'managements' ]]
-    
-    render_mgmt_timeline(management_data)
-
-  })
-
-}
-
-render_search_timeline_hover <- function(full_cache_data, input, output, exp_name, subexp_name, selected_input_id){
-  
-  output$search_timeline_info <- renderUI({
-    
-    subexp_data <- full_cache_data[[ exp_name ]][[ subexp_name ]]
-    
-    render_timeline_hover(selected_input_id, subexp_data, input)
-    
-  })
-}
-
 
 # home page ui 
 home_page <- fluidPage(theme = shinytheme('flatly'),

--- a/app.R
+++ b/app.R
@@ -583,6 +583,29 @@ search_server <- function(input, output, session){
     render_mgmt_search(full_cache_data, exp_name(), subexp_name())
   })
   
+  output$search_timeline_info <- renderUI({
+    
+    req(input[[ paste0('search_timeline_selected') ]])
+    selected <- input[[ paste0('search_timeline_selected') ]]
+    
+    management_data <- full_cache_data[[ subexp_name ]][[ 'managements' ]]
+    selected_record <- management_data[ as.numeric(selected), ]
+    
+    formatted_notes <- ''
+    if (selected_record[[ 'notes' ]] != '') {
+      formatted_notes <- paste0('<br><br>', selected_record[[ 'notes' ]])
+    }
+    
+    
+    wellPanel(class = 'mgmt-select-info',
+              HTML(paste0(
+                selected_record[[ 'mgmttype' ]], '<br>',
+                selected_record[[ 'date' ]],
+                formatted_notes
+              ))
+    )
+    
+  })
 }
 
 # create routing

--- a/app.R
+++ b/app.R
@@ -124,7 +124,7 @@ render_cultivar_menu <- function(subexp_name, id_str, input, output, full_cache_
 
 # render box plot time series from trait records in a given subexperiment, for the selected variable
 # if a cultivar is selected, render line plot from trait records for that cultivar
-render_trait_plot <- function(subexp_name, id_str, input, output, full_cache_data) {
+render_plot <- function(subexp_name, id_str, input, output, full_cache_data) {
   
   output[[ paste0('trait_plot_', id_str) ]] <- renderPlot({
     
@@ -136,53 +136,12 @@ render_trait_plot <- function(subexp_name, id_str, input, output, full_cache_dat
     selected_cultivar <- input[[ paste0('selected_cultivar_', id_str) ]]
     
     plot_data <- selected_subexp_data[[ 'trait_data' ]][[ selected_variable ]][[ 'traits' ]]
-    data_max <- max(plot_data[[ 'mean' ]])
-    
     units <- selected_subexp_data[[ 'trait_data' ]][[ selected_variable ]][[ 'units' ]]
+    start_date <- as.Date(selected_subexp_data[[ 'start_date' ]])
+    end_date <- as.Date(selected_subexp_data[[ 'end_date' ]])
     
-    unique_vals <- unique(plot_data[[ 'mean' ]])
-    all_vals_integers <- all(unique_vals %% 1 == 0)
-    num_unique_vals <- length(unique_vals)
-
-    plot_data$method[is.na(plot_data$method) | plot_data$method == 'NA'] <- 'Not Provided'
-
-    trait_plot <- ggplot(data = plot_data, aes(x = as.Date(date), y = mean, color = method)) +
-      scale_colour_brewer(palette = "Set1")
-
-    {
-        if ((num_unique_vals < 20) & (max(unique_vals) < 30) & all_vals_integers) {
-          trait_plot <- trait_plot + 
-            geom_count() + 
-            geom_vline(aes(xintercept = as.numeric(as.Date(date))),
-                       color = 'grey')
-        } else {
-          trait_plot <- trait_plot + 
-            geom_violin(scale = 'width', width = 1, aes(group = as.Date(date))) +
-            geom_boxplot(outlier.alpha = 0.25, width = 0.2, aes(group = as.Date(date)))
-        }
-      }
-      
-    if (selected_cultivar != 'None') {
-        title <- paste0(selected_variable, '\nCultivar ', selected_cultivar, ' in red')
-        trait_plot <- trait_plot + 
-          geom_point(data = subset(plot_data, cultivar_name == selected_cultivar), 
-                     aes(x = as.Date(date), y = mean, group = site_id)) +
-          geom_line(data = subset(plot_data, cultivar_name == selected_cultivar), 
-                     size = 0.5, alpha = 0.5, aes(x = as.Date(date), y = mean, group = site_id)) 
-    } else {
-        title <- selected_variable
-    }
+    render_trait_plot(plot_data, selected_variable, selected_cultivar, units, start_date, end_date)
     
-    trait_plot + 
-      labs(
-        title = paste0(title, '\n'),
-        x = "Date",
-        y = units
-      ) +
-      theme_bw() + 
-      theme(text = element_text(size = 20), axis.text.x = element_text(angle = 45, hjust = 1)) +
-      xlim(as.Date(selected_subexp_data[[ 'start_date' ]]), as.Date(selected_subexp_data[[ 'end_date' ]])) +
-      ylim(0, data_max)
   })
 }
 

--- a/app.R
+++ b/app.R
@@ -168,6 +168,7 @@ render_trait_plot <- function(plot_data, selected_variable, selected_cultivar, u
     theme(text = element_text(size = 20), axis.text.x = element_text(angle = 45, hjust = 1)) +
     xlim(start_date, end_date) +
     ylim(0, data_max)
+  
 }
 
 # render box plot time series from trait records in a given subexperiment, for the selected variable
@@ -565,7 +566,7 @@ search_server <- function(input, output, session){
 # pass in ui and server for each page
 router <- make_router(
   route("/", home_page, home_server),
-  route("search", search_page, search_server)
+  route("/search", search_page, search_server)
 )
 
 # Create output for home page route

--- a/app.R
+++ b/app.R
@@ -566,7 +566,7 @@ search_server <- function(input, output, session){
 # pass in ui and server for each page
 router <- make_router(
   route("/", home_page, home_server),
-  route("/search", search_page, search_server)
+  route("search", search_page, search_server)
 )
 
 # Create output for home page route

--- a/app.R
+++ b/app.R
@@ -42,17 +42,6 @@ if(dir.exists(image_dir)){
   image_dates <- as.Date(unique(unlist(str_extract_all(list.files(image_dir),'[0-9]{4}-[0-9]{2}-[0-9]{2}'))))
 } 
 
-  
-
-# set page UI
-ui <- fluidPage(theme = shinytheme('flatly'),
-  tags$link(rel = 'stylesheet', type = 'text/css', href = 'style.css'),
-  title = 'TERRA-REF Experiment Data',
-  tags$img(src = 'logo.png', class = 'push-out'),
-  # destination for all dynamic UI elements
-  uiOutput('page_content')
-)
-
 # render UI for a given subexperiment
 render_subexp_ui <- function(subexp_name, exp_name) {
   

--- a/app.R
+++ b/app.R
@@ -472,6 +472,15 @@ render_search_plot <- function(full_cache_data, exp_name,
   
 }
 
+# home page ui (/)
+home_page <- fluidPage(theme = shinytheme('flatly'),
+                       tags$link(rel = 'stylesheet', type = 'text/css', href = 'style.css'),
+                       title = 'TERRA-REF Experiment Data',
+                       tags$img(src = 'logo.png', class = 'push-out'),
+                       # destination for all dynamic UI elements
+                       uiOutput('home_page_content')
+)
+
 server <- function(input, output) {
   
   # load 'full_cache_data' object from cache file

--- a/app.R
+++ b/app.R
@@ -8,6 +8,7 @@ library(shinythemes)
 library(scales)
 library(stringr)
 library(kableExtra)
+library(shiny.router)
 
 source('render-site-map.R')
 

--- a/app.R
+++ b/app.R
@@ -582,19 +582,3 @@ server <- shinyServer(function(input, output, session) {
 })
 
 shinyApp(ui = ui, server = server)
-server <- function(input, output) {
-  
-  # load 'full_cache_data' object from cache file
-  full_cache_data <- load_cache(full_cache_data)
-  
-  # render UI for all available experiments
-  output$page_content <- renderUI({
-    subexp_tabs <- lapply(names(full_cache_data), render_experiment_ui, full_cache_data)
-    do.call(tabsetPanel, subexp_tabs)
-  })
-  
-  # render outputs for all available experiments
-  lapply(names(full_cache_data), render_experiment_output, input, output, full_cache_data)
-}
-
-shinyApp(ui = ui, server = server)

--- a/app.R
+++ b/app.R
@@ -414,7 +414,7 @@ render_subexp_output <- function(subexp_name, exp_name, input, output, full_cach
   
   render_cultivar_menu(subexp_name, id_str, input, output, full_cache_data)
   
-  render_trait_plot(subexp_name, id_str, input, output, full_cache_data)
+  render_plot(subexp_name, id_str, input, output, full_cache_data)
   
   render_plot_hover(subexp_name, id_str, input, output, full_cache_data)
   

--- a/app.R
+++ b/app.R
@@ -576,6 +576,11 @@ ui <- shinyUI(fluidPage(
   router_ui()
 ))
 
+# Add router to the server
+server <- shinyServer(function(input, output, session) {
+  router(input, output, session)
+})
+
 server <- function(input, output) {
   
   # load 'full_cache_data' object from cache file

--- a/app.R
+++ b/app.R
@@ -460,6 +460,18 @@ render_search_map <- function(full_cache_data, exp_name,
   }
 }
 
+render_search_plot <- function(full_cache_data, exp_name,
+                               subexp_name, var, cultivar){
+  
+  subexp_data <- full_cache_data[[ exp_name ]][[ subexp_name ]]
+  traits <- subexp_data[[ 'trait_data' ]][[ var ]][[ 'traits' ]]
+  units <- subexp_data[[ 'trait_data' ]][[ var ]][[ 'units' ]]
+  start_date <- as.Date(subexp_data[[ 'start_date' ]])
+  end_date <- as.Date(subexp_data[[ 'end_date' ]])
+  render_trait_plot(traits, var, cultivar, units, start_date, end_date)
+  
+}
+
 server <- function(input, output) {
   
   # load 'full_cache_data' object from cache file

--- a/app.R
+++ b/app.R
@@ -490,6 +490,22 @@ search_page <- fluidPage(theme = shinytheme('flatly'),
                          uiOutput('search_page_content')
 )
 
+# home page server
+home_server <- function(input, output, session) {
+  
+  # load 'full_cache_data' object from cache file
+  full_cache_data <- load_cache(full_cache_data)
+  
+  # render UI for all available experiments
+  output$home_page_content <- renderUI({
+    subexp_tabs <- lapply(names(full_cache_data), render_experiment_ui, full_cache_data)
+    do.call(tabsetPanel, subexp_tabs)
+  })
+  
+  # render outputs for all available experiments
+  lapply(names(full_cache_data), render_experiment_output, input, output, full_cache_data)
+}
+
 server <- function(input, output) {
   
   # load 'full_cache_data' object from cache file

--- a/app.R
+++ b/app.R
@@ -481,10 +481,10 @@ search_server <- function(input, output, session){
   full_cache_data <- load_cache(full_cache_data)
   
   # get url parameters
-  exp_name <- reactive({ ifelse(is.null(get_query_param()$exp),
+  exp_name <- reactive({ ifelse(is.null(get_query_param()$exp_name),
                                 NULL, as.character(get_query_param()$exp_name))})
   
-  subexp_name <- reactive({ ifelse(is.null(get_query_param()$subexp),
+  subexp_name <- reactive({ ifelse(is.null(get_query_param()$subexp_name),
                                    NULL, as.character(get_query_param()$subexp_name)) })
   
   var <- reactive({ ifelse(is.null(get_query_param()$var),

--- a/app.R
+++ b/app.R
@@ -564,6 +564,13 @@ search_server <- function(input, output, session){
   })
 }
 
+# create routing
+# pass in ui and server for each page
+router <- make_router(
+  route("/", home_page, home_server),
+  route("search", search_page, search_server)
+)
+
 server <- function(input, output) {
   
   # load 'full_cache_data' object from cache file

--- a/app.R
+++ b/app.R
@@ -443,6 +443,23 @@ render_experiment_output <- function(experiment_name, input, output, full_cache_
   lapply(names(full_cache_data[[ experiment_name ]]), render_subexp_output, experiment_name, input, output, full_cache_data[[ experiment_name ]])
 }
 
+render_search_map <- function(full_cache_data, exp_name,
+                              subexp_name, var,
+                              cultivar = 'None', date){
+  traits <- full_cache_data[[ exp_name ]][[ subexp_name ]][[ 'trait_data' ]][[ var ]][[ 'traits' ]]
+  if (cultivar != 'None'){
+    traits <- subset(traits, cultivar_name == cultivar)
+  }
+  if(dir.exists(image_dir) & (date %in% image_dates)){
+    # render site map with fullfield image if thumbs available for selected date
+    overlay_image <- 1
+    render_site_map(var, traits, date, var, overlay_image)
+  }else{
+    # render site map without fullfield image
+    render_site_map(var, traits, date, var)
+  }
+}
+
 server <- function(input, output) {
   
   # load 'full_cache_data' object from cache file

--- a/app.R
+++ b/app.R
@@ -472,13 +472,22 @@ render_search_plot <- function(full_cache_data, exp_name,
   
 }
 
-# home page ui (/)
+# home page ui 
 home_page <- fluidPage(theme = shinytheme('flatly'),
                        tags$link(rel = 'stylesheet', type = 'text/css', href = 'style.css'),
                        title = 'TERRA-REF Experiment Data',
                        tags$img(src = 'logo.png', class = 'push-out'),
                        # destination for all dynamic UI elements
                        uiOutput('home_page_content')
+)
+
+# search page ui
+search_page <- fluidPage(theme = shinytheme('flatly'),
+                         tags$link(rel = 'stylesheet', type = 'text/css', href = 'style.css'),
+                         title = 'TERRA-REF Experiment Data',
+                         tags$img(src = 'logo.png', class = 'push-out'),
+                         # destination for all UI elements
+                         uiOutput('search_page_content')
 )
 
 server <- function(input, output) {

--- a/app.R
+++ b/app.R
@@ -571,6 +571,11 @@ router <- make_router(
   route("search", search_page, search_server)
 )
 
+# Create output for home page route
+ui <- shinyUI(fluidPage(
+  router_ui()
+))
+
 server <- function(input, output) {
   
   # load 'full_cache_data' object from cache file

--- a/app.R
+++ b/app.R
@@ -514,10 +514,10 @@ search_server <- function(input, output, session){
   
   # get url parameters
   exp_name <- reactive({ ifelse(is.null(get_query_param()$exp),
-                                NULL, as.character(get_query_param()$exp))})
+                                NULL, as.character(get_query_param()$exp_name))})
   
   subexp_name <- reactive({ ifelse(is.null(get_query_param()$subexp),
-                                   NULL, as.character(get_query_param()$subexp)) })
+                                   NULL, as.character(get_query_param()$subexp_name)) })
   
   var <- reactive({ ifelse(is.null(get_query_param()$var),
                            NULL, as.character(get_query_param()$var)) })

--- a/render-home-outputs.R
+++ b/render-home-outputs.R
@@ -1,0 +1,222 @@
+# directory containing full-field images
+image_dir <- '~/data/terraref/sites/ua-mac/Level_2/rgb_fullfield/_thumbs'
+
+if(dir.exists(image_dir)){
+  # dates that have full-field images
+  image_dates <- as.Date(unique(unlist(str_extract_all(list.files(image_dir),'[0-9]{4}-[0-9]{2}-[0-9]{2}'))))
+} 
+
+# render functions for home page
+
+# render selection menu from available variables in a given subexperiment
+render_variable_menu <- function(subexp_name, id_str, output, full_cache_data) {
+  
+  variable_names <- names(full_cache_data[[ subexp_name ]][[ 'trait_data' ]])
+  
+  output[[ paste0('variable_select_', id_str) ]] <- renderUI({
+    selectInput(paste0('selected_variable_', id_str), 'Variable', variable_names)
+  })
+}
+
+# render selection menu from available cultivars in a given subexperiment, for the selected variable
+render_cultivar_menu <- function(subexp_name, id_str, input, output, full_cache_data) {
+  
+  output[[ paste0('cultivar_select_', id_str) ]] <- renderUI({
+    
+    req(input[[ paste0('selected_variable_', id_str) ]])
+    
+    trait_records <- full_cache_data[[ subexp_name ]][[ 'trait_data' ]][[ input[[ paste0('selected_variable_', id_str) ]] ]][[ 'traits' ]]
+    unique_cultivars <- unique(trait_records[[ 'cultivar_name' ]])
+    
+    selectInput(paste0('selected_cultivar_', id_str), 'Cultivar', c('None', unique_cultivars))
+  })
+}
+
+render_home_plot <- function(subexp_name, id_str, input, output, full_cache_data) {
+  
+  output[[ paste0('trait_plot_', id_str) ]] <- renderPlot({
+    
+    req(input[[ paste0('selected_variable_', id_str) ]])
+    req(input[[ paste0('selected_cultivar_', id_str) ]])
+    
+    selected_subexp_data <- full_cache_data[[ subexp_name ]]
+    selected_variable <- input[[ paste0('selected_variable_', id_str) ]]
+    selected_cultivar <- input[[ paste0('selected_cultivar_', id_str) ]]
+    
+    plot_data <- selected_subexp_data[[ 'trait_data' ]][[ selected_variable ]][[ 'traits' ]]
+    units <- selected_subexp_data[[ 'trait_data' ]][[ selected_variable ]][[ 'units' ]]
+    start_date <- as.Date(selected_subexp_data[[ 'start_date' ]])
+    end_date <- as.Date(selected_subexp_data[[ 'end_date' ]])
+    
+    render_trait_plot(plot_data, selected_variable, selected_cultivar, units, start_date, end_date)
+    
+  })
+}
+
+render_home_mgmt_timeline <- function(subexp_name, id_str, input, output, full_cache_data) {
+  
+  output[[ paste0('mgmt_timeline_', id_str) ]] <- renderTimevis({
+    
+    management_data <- full_cache_data[[ subexp_name ]][[ 'managements' ]]
+    
+    render_mgmt_timeline(management_data)
+    
+  })
+}
+
+render_home_plot_hover <- function(subexp_name, id_str, input, output, full_cache_data) {
+  
+  output[[ paste0('plot_hover_info_', id_str) ]] <- renderUI({
+    
+    render_plot_hover(paste0('plot_hover_', id_str), input)
+    
+  })
+}
+
+
+render_home_timeline_hover <- function(subexp_name, id_str, input, output, full_cache_data) {
+  
+  output[[ paste0('mgmt_select_info_', id_str) ]] <- renderUI({
+    
+    subexp_data <- full_cache_data[[ subexp_name ]]
+    
+    render_timeline_hover(paste0('mgmt_timeline_', id_str, '_selected'), subexp_data, input)
+    
+  })
+}
+
+render_home_map <- function(subexp_name, id_str, input, output, full_cache_data) {
+  
+  # render slider input from dates in a given subexperiment
+  output[[ paste0('map_date_slider_', id_str) ]] <- renderUI({
+    
+    sliderInput(paste0('map_date_', id_str), 'Date',
+                as.Date(full_cache_data[[ subexp_name ]][[ 'start_date']]),
+                as.Date(full_cache_data[[ subexp_name ]][[ 'end_date' ]]),
+                as.Date(full_cache_data[[ subexp_name ]][[ 'end_date' ]]))
+    
+  })
+  
+  output[[ paste0('scan_options_table_', id_str) ]] <- renderText({
+    
+    req(input[[ paste0('map_date_', id_str) ]]) 
+    render_date <- input[[ paste0('map_date_', id_str) ]]
+    
+    # display scan options table for selected date if thumbs exist for date
+    if(dir.exists(image_dir) & (render_date %in% image_dates)){
+      
+      image_paths <- list.files(image_dir, pattern = as.character(render_date))
+      scan_matches <- unlist(str_match_all(image_paths,
+                                           'rgb_fullfield_L2_ua-mac_[0-9]{4}-[0-9]{2}-[0-9]{2}_(.*)_rgb_thumb\\.tif'))
+      scan_names <- str_replace_all(scan_matches[-grep('\\.tif', scan_matches)],
+                                    '_',
+                                    ' ')
+      scan_names_df <- data.frame(scan_number = 1:length(scan_names),
+                                  scan_name = scan_names)
+      scan_names_kable <- kable(scan_names_df) %>% kable_styling()
+      
+    }else{
+      return()
+    }
+    
+  })
+  
+  # render heat map of sites from trait records in a given subexperiment, for the selected date, variable and cultivar
+  output[[ paste0('site_map_', id_str) ]] <- renderLeaflet({
+    
+    req(input[[ paste0('selected_variable_', id_str) ]])
+    req(input[[ paste0('selected_cultivar_', id_str) ]])
+    req(input[[ paste0('map_date_', id_str) ]])
+    
+    selected_variable <- input[[ paste0('selected_variable_', id_str) ]]
+    selected_cultivar <- input[[ paste0('selected_cultivar_', id_str) ]]
+    render_date <- input [[ paste0('map_date_', id_str) ]]
+    
+    traits <- full_cache_data[[ subexp_name ]][[ 'trait_data' ]][[ selected_variable ]][[ 'traits' ]]
+    
+    if (selected_cultivar != 'None'){
+      traits <- subset(traits, cultivar_name == selected_cultivar)
+    }
+    
+    if(dir.exists(image_dir) & (render_date %in% image_dates)){
+      # render site map with fullfield image if thumbs available for selected date
+      overlay_image <- 1
+      render_site_map(selected_variable, traits, render_date, selected_variable, overlay_image)
+    }else{
+      render_site_map(selected_variable, traits, render_date, selected_variable)
+    }
+    
+  })
+}
+
+render_download_info <- function(exp_name, subexp_name, id_str, input, output, full_cache_data){
+  
+  output[[ paste0('download_info_', id_str) ]] <- renderUI({
+    
+    req(input[[ paste0('selected_variable_', id_str) ]])
+    selected_variable <- input[[ paste0('selected_variable_', id_str) ]]
+    
+    trait_name <- full_cache_data[[ subexp_name ]][[ 'trait_data' ]][[ selected_variable ]][[ 'name' ]]
+    
+    if(exp_name == 'Danforth Sorghum Pilot'){
+      site <- 'Danforth Plant Science Center Bellweather Phenotyping Facility'
+    }else{
+      site <- paste0('~', gsub('MAC ', '', exp_name))
+    }
+    
+    text_1 <- "<h1 style='font-size:30px;'>How to access data</h1>"
+    text_2 <- paste0("You can access <strong><em>",
+                     selected_variable,
+                     "</strong></em> data for <strong><em>",
+                     exp_name,
+                     "</strong></em>, using either:<br>")
+    text_3 <- "1.) BETYdb API<br>2.) R traits package"
+    text_4 <- "<br><h2 style='font-size:25px;'>API key</h2>"
+    text_5 <- paste0("Both methods will require an <strong>API key</strong>.<br><br>",
+                     "You can get an API key by signing up for the TERRA Ref BETYdb traits database. ",
+                     "Register for BETYdb at ",
+                     "<a href='https://terraref.ncsa.illinois.edu/bety/signup'>",
+                     "https://terraref.ncsa.illinois.edu/bety/signup</a>.<hr>")
+    text_6 <- "<h2 style='font-size:25px;'>R traits package</h2><br>"
+    text_7 <- "Install the traits package from CRAN using: <code>install.packages('traits')</code>.<br><br>"
+    text_8 <- paste0("You can then use the following chunk of R code to access the data: <br><br>",
+                     "<code>library(traits)</code><br><br>",
+                     "<code>options(betydb_url = ",
+                     "'https://terraref.ncsa.illinois.edu/bety/'",
+                     ", betydb_api_version = 'beta', ",
+                     "betydb_key = 'YOUR_API_KEY')</code><br><br>")
+    text_9 <- paste0("<code>",
+                     trait_name)
+    text_10 <- paste0(" <- betydb_query(trait = '", trait_name, "', ")
+    text_11 <- paste0("sitename = '", site, "', ")
+    text_12 <- paste0("limit = 'none')</code>")
+    text_13 <- paste0("<hr>",
+                      "<h2 style='font-size:25px;'>BETYdb API</h2><br>",
+                      "You can also access the data at this URL:<br>")
+    text_14 <- paste0("<a>https://terraref.ncsa.illinois.edu/bety/api/v1/search?",
+                      "trait=",
+                      trait_name,
+                      "&sitename=",
+                      site,
+                      "&limit=none&key=YOUR_API_KEY</a>.<br><br>",
+                      "See API <a href='https://www.betydb.org/api/docs'>documentation</a> for details.")
+    text_15 <- paste0("<hr>",
+                      "<h1 style='font-size:30px;'>TERRA REF Tutorials</h1><br>",
+                      "For more detailed information on how to access data, take a look at our tutorials.<br><br>",
+                      "GitHub repository: <a href='https://github.com/terraref/tutorials'>",
+                      "https://github.com/terraref/tutorials</a><br>",
+                      "How to access data using R traits package: ",
+                      "<a href='https://github.com/terraref/tutorials/tree/master/traits/03-access-r-traits.Rmd'>",
+                      "traits/03-access-r-traits.Rmd</a><br>",
+                      "How to access data using BETYdb API: ",
+                      "<a href='https://github.com/terraref/tutorials/tree/master/traits/02-betydb-api-access.Rmd'>",
+                      "traits/02-betydb-api-access.Rmd</a><br>")
+    
+    download_text <- HTML(paste(text_1, text_2, text_3,
+                                text_4, text_5, text_6,
+                                text_7, text_8, text_9,
+                                text_10, text_11, text_12,
+                                text_13, text_14, text_15))
+  })
+  
+}

--- a/render-mgmt-timeline.R
+++ b/render-mgmt-timeline.R
@@ -1,0 +1,44 @@
+library(timevis)
+
+# render timeline from management records in a given subexperiment
+render_mgmt_timeline <- function(management_data){
+  
+  if (nrow(management_data) > 0) {
+    
+    types <- management_data[[ 'mgmttype' ]]
+    dates <- management_data[[ 'date' ]]
+    
+    timeline_data <- data.frame(
+      id = 1:nrow(management_data),
+      content = types,
+      start = dates
+    )
+    
+    timevis(
+      timeline_data,
+      options = list(zoomable = FALSE)
+    )
+  }
+  
+}
+
+# render info box for date, type, and notes of selected (clicked) timeline item
+render_timeline_hover <- function(selected_input_id, subexp_data, input){
+  
+  req(input[[ selected_input_id ]])
+  selected <- input[[ selected_input_id ]]
+  
+  management_data <- subexp_data[[ 'managements' ]]
+  selected_record <- management_data[ as.numeric(selected), ]
+  formatted_notes <- ''
+  if (selected_record[[ 'notes' ]] != '') {
+    formatted_notes <- paste0('<br><br>', selected_record[[ 'notes' ]])
+  }
+  wellPanel(class = 'mgmt-select-info',
+            HTML(paste0(
+              selected_record[[ 'mgmttype' ]], '<br>',
+              selected_record[[ 'date' ]],
+              formatted_notes
+            ))
+  )
+}

--- a/render-search-outputs.R
+++ b/render-search-outputs.R
@@ -1,0 +1,67 @@
+# directory containing full-field images
+image_dir <- '~/data/terraref/sites/ua-mac/Level_2/rgb_fullfield/_thumbs'
+
+if(dir.exists(image_dir)){
+  # dates that have full-field images
+  image_dates <- as.Date(unique(unlist(str_extract_all(list.files(image_dir),'[0-9]{4}-[0-9]{2}-[0-9]{2}'))))
+} 
+
+# render functions for search page
+render_search_map <- function(full_cache_data, input, output, exp_name,
+                              subexp_name, var,
+                              cultivar = 'None', date){
+  
+  output$search_map <- renderLeaflet({
+    
+    traits <- full_cache_data[[ exp_name ]][[ subexp_name ]][[ 'trait_data' ]][[ var ]][[ 'traits' ]]
+    if (cultivar != 'None'){
+      traits <- subset(traits, cultivar_name == cultivar)
+    }
+    if(dir.exists(image_dir) & (date %in% image_dates)){
+      # render site map with fullfield image if thumbs available for selected date
+      overlay_image <- 1
+      render_site_map(var, traits, date, var, overlay_image)
+    }else{
+      # render site map without fullfield image
+      render_site_map(var, traits, date, var)
+    }
+    
+  })
+}
+
+render_search_plot <- function(full_cache_data, input, output, exp_name,
+                               subexp_name, var, cultivar){
+  
+  output$search_plot <- renderPlot({
+    subexp_data <- full_cache_data[[ exp_name ]][[ subexp_name ]]
+    traits <- subexp_data[[ 'trait_data' ]][[ var ]][[ 'traits' ]]
+    units <- subexp_data[[ 'trait_data' ]][[ var ]][[ 'units' ]]
+    start_date <- as.Date(subexp_data[[ 'start_date' ]])
+    end_date <- as.Date(subexp_data[[ 'end_date' ]])
+    render_trait_plot(traits, var, cultivar, units, start_date, end_date)
+  })
+  
+}
+
+render_search_mgmt_timeline <- function(full_cache_data, output, exp_name, subexp_name){
+  
+  output$search_timeline <- renderTimevis({
+    
+    management_data <- full_cache_data[[ exp_name ]][[ subexp_name ]][[ 'managements' ]]
+    
+    render_mgmt_timeline(management_data)
+    
+  })
+  
+}
+
+render_search_timeline_hover <- function(full_cache_data, input, output, exp_name, subexp_name, selected_input_id){
+  
+  output$search_timeline_info <- renderUI({
+    
+    subexp_data <- full_cache_data[[ exp_name ]][[ subexp_name ]]
+    
+    render_timeline_hover(selected_input_id, subexp_data, input)
+    
+  })
+}

--- a/render-trait-plot.R
+++ b/render-trait-plot.R
@@ -1,0 +1,73 @@
+library(ggplot2)
+
+
+# render box plot time series from trait records in a given subexperiment, for the selected variable
+# if a cultivar is selected, render line plot from trait records for that cultivar
+render_trait_plot <- function(plot_data, selected_variable, selected_cultivar, units, start_date, end_date){
+  data_max <- max(plot_data[[ 'mean' ]])
+  unique_vals <- unique(plot_data[[ 'mean' ]])
+  all_vals_integers <- all(unique_vals %% 1 == 0)
+  num_unique_vals <- length(unique_vals)
+  
+  plot_data$method[is.na(plot_data$method) | plot_data$method == 'NA'] <- 'Not Provided'
+  
+  trait_plot <- ggplot(data = plot_data, aes(x = as.Date(date), y = mean, color = method)) +
+    scale_colour_brewer(palette = "Set1")
+  
+  {
+    if ((num_unique_vals < 20) & (max(unique_vals) < 30) & all_vals_integers) {
+      trait_plot <- trait_plot + 
+        geom_count() + 
+        geom_vline(aes(xintercept = as.numeric(as.Date(date))),
+                   color = 'grey')
+    } else {
+      trait_plot <- trait_plot + 
+        geom_violin(scale = 'width', width = 1, aes(group = as.Date(date))) +
+        geom_boxplot(outlier.alpha = 0.25, width = 0.2, aes(group = as.Date(date)))
+    }
+    }
+  
+  if (selected_cultivar != 'None') {
+    title <- paste0(selected_variable, '\nCultivar ', selected_cultivar, ' in red')
+    trait_plot <- trait_plot + 
+      geom_point(data = subset(plot_data, cultivar_name == selected_cultivar), 
+                 aes(x = as.Date(date), y = mean, group = site_id)) +
+      geom_line(data = subset(plot_data, cultivar_name == selected_cultivar), 
+                size = 0.5, alpha = 0.5, aes(x = as.Date(date), y = mean, group = site_id)) 
+  } else {
+    title <- selected_variable
+  }
+  
+  trait_plot + 
+    labs(
+      title = paste0(title, '\n'),
+      x = "Date",
+      y = units
+    ) +
+    theme_bw() + 
+    theme(text = element_text(size = 20), axis.text.x = element_text(angle = 45, hjust = 1)) +
+    xlim(start_date, end_date) +
+    ylim(0, data_max)
+  
+}
+
+# render info box for date and value of cursor when hovering box/line plot
+render_plot_hover <- function(hover_input_id, input){
+  
+  req(input[[ hover_input_id ]])
+  
+  hover <- input[[ hover_input_id ]]
+  
+  wellPanel(class = 'plot-hover-info push-down',
+            HTML(paste0(
+              'Date', '<br>',
+              toString(
+                as.Date(hover$x, origin = lubridate::origin)
+              ),
+              '<br><br>',
+              'Value', '<br>',
+              format(round(hover$y, 2))
+            ))
+  )
+  
+}

--- a/render-trait-plot.R
+++ b/render-trait-plot.R
@@ -45,7 +45,7 @@ render_trait_plot <- function(plot_data, selected_variable, selected_cultivar, u
       y = units
     ) +
     theme_bw() + 
-    theme(text = element_text(size = 20), axis.text.x = element_text(angle = 45, hjust = 1)) +
+    theme(text = element_text(size = 20), axis.text.x = element_text(angle = 45, hjust = 1), legend.position = 'bottom') +
     xlim(start_date, end_date) +
     ylim(0, data_max)
   


### PR DESCRIPTION
This addresses #45.

Users can pass in the following parameters to the `/search` route url:

* exp_name
* subexp_name
* var (here the variable name must exactly match the label, which includes units and spaces)
* cultivar
* date

Home page url: `http://127.0.0.1:6309/#!/`

Example search url: 
`http://127.0.0.1:6309/?exp_name=MAC+Season+1&subexp_name=Biomass&var=Canopy+Height+(cm)&cultivar=None&date=2016-07-14#!/search`
