### PR TITLE
Move trait plot legend

### DIFF
--- a/app.R
+++ b/app.R
@@ -190,7 +190,7 @@ render_trait_plot <- function(subexp_name, id_str, input, output, full_cache_dat
         y = units
       ) +
       theme_bw() + 
-      theme(text = element_text(size = 20), axis.text.x = element_text(angle = 45, hjust = 1)) +
+      theme(text = element_text(size = 20), axis.text.x = element_text(angle = 45, hjust = 1), legend.position = 'bottom') +
       xlim(as.Date(selected_subexp_data[[ 'start_date' ]]), as.Date(selected_subexp_data[[ 'end_date' ]])) +
       ylim(0, data_max)
   })


### PR DESCRIPTION
This addresses issue #52.

The trait plot legend is now positioned to be at the bottom rather than on the side.